### PR TITLE
Fix downloads, folder uploads, and nested folder path handling

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -60,7 +60,12 @@ def parse_path(path_json: str) -> List[str]:
 
 def serialize_path(path: List[str]) -> str:
     """Serialize path list to JSON"""
-    return json.dumps(path)
+    return json.dumps(path, separators=(",", ":"))
+
+
+def normalize_path(path_json: str) -> str:
+    """Normalize incoming path JSON for stable DB comparisons."""
+    return serialize_path(parse_path(path_json or "[]"))
 
 
 @router.get("", response_model=List[FileResponseSchema])
@@ -81,7 +86,9 @@ async def list_files(
         query = query.where(FileModel.is_starred == True)
     
     if path:
-        query = query.where(FileModel.path == path)
+        normalized_path = normalize_path(path)
+        legacy_path = json.dumps(parse_path(path))
+        query = query.where(FileModel.path.in_([normalized_path, legacy_path]))
     
     result = await db.execute(query.order_by(FileModel.type, FileModel.name))
     files = result.scalars().all()
@@ -137,6 +144,7 @@ async def upload_files(
                     if not chunk:
                         break
                     file_size += len(chunk)
+                    await f.write(chunk)
                     
                     # Per-file size limit check
                     if settings.max_file_size_bytes > 0 and file_size > settings.max_file_size_bytes:
@@ -178,7 +186,7 @@ async def upload_files(
             type=get_file_type(file.filename, mime_type),
             mime_type=mime_type,
             size=file_size,
-            path=path,
+            path=normalize_path(path),
             storage_path=storage_filepath,
             thumbnail_path=thumb_path,
             owner_id=current_user.id,
@@ -472,7 +480,7 @@ async def trash_file(
     # If folder, recursively trash all children
     if file.type == "folder":
         folder_path = parse_path(file.path) + [file.name]
-        folder_path_json = json.dumps(folder_path)
+        folder_path_json = serialize_path(folder_path)
         children_result = await db.execute(
             select(FileModel).where(
                 and_(
@@ -534,7 +542,7 @@ async def restore_file(
     # If folder, recursively restore all children
     if file.type == "folder":
         folder_path = parse_path(file.path) + [file.name]
-        folder_path_json = json.dumps(folder_path)
+        folder_path_json = serialize_path(folder_path)
         children_result = await db.execute(
             select(FileModel).where(
                 and_(
@@ -592,7 +600,7 @@ async def delete_file_permanently(
     # If folder, recursively delete all children first
     if file.type == "folder":
         folder_path = parse_path(file.path) + [file.name]
-        folder_path_json = json.dumps(folder_path)
+        folder_path_json = serialize_path(folder_path)
         children_result = await db.execute(
             select(FileModel).where(
                 and_(

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -24,7 +24,7 @@ def parse_path(path_json: str) -> List[str]:
 
 
 def serialize_path(path: List[str]) -> str:
-    return json.dumps(path)
+    return json.dumps(path, separators=(",", ":"))
 
 
 @router.post("", response_model=FileResponseSchema, status_code=status.HTTP_201_CREATED)


### PR DESCRIPTION
### Motivation
- Uploads were being streamed but chunks were not written to disk, causing 0-byte/corrupted downloads.
- Folder uploads and nested-folder operations failed due to inconsistent JSON formatting of stored `path` values across code paths.
- Recursive folder operations relied on a different path formatting which prevented proper child detection for trash/restore/delete.

### Description
- Write streamed upload chunks to disk by calling `await f.write(chunk)` inside the upload loop in `files.py` so files are persisted correctly.
- Standardize path serialization to a compact, stable JSON form using `json.dumps(..., separators=(",", ":"))` via `serialize_path` in both `files.py` and `folders.py`.
- Add `normalize_path(path_json)` and use it when storing file `path` and when querying to normalize incoming path parameters for reliable DB comparisons.
- Make listing backward-compatible by matching both the normalized path and the legacy spaced JSON string (`FileModel.path.in_([normalized, legacy])`) so older records remain reachable.
- Update recursive folder child queries (trash/restore/delete) to use the same `serialize_path` output so nested children are detected consistently.

### Testing
- Ran `python -m compileall backend/app` to validate syntax and module importability; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3aec7b2f4832aa78b4fc903b06edc)