### PR TITLE
Fix redundant double-assignment in rename ActivityLog construction

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -1387,10 +1387,9 @@ async def update_file(
         activity = ActivityLog(
             user_id=current_user.id,
             action="rename",
-            file_name=f"{old_name} → {update.name}",
+            file_name=f"{old_name} -> {safe_name}",
         )
         db.add(activity)
-        activity.file_name = f"{old_name} -> {safe_name}"
 
     if update.path is not None:
         file.path = serialize_path(update.path)

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -69,6 +69,24 @@ def sanitize_filename(filename: Optional[str]) -> str:
     return sanitized or "unnamed"
 
 
+def sanitize_rename_target(filename: Optional[str]) -> str:
+    """Normalize rename input and reject values that collapse to an empty name."""
+    safe_name = sanitize_filename(filename)
+    if safe_name != "unnamed":
+        return safe_name
+
+    raw_name = (filename or "").replace("\x00", "")
+    for char in raw_name:
+        if char in {"/", "\\", "\r", "\n"}:
+            return safe_name
+        if unicodedata.category(char).startswith("C"):
+            continue
+        if char not in {" ", "."}:
+            return safe_name
+
+    raise HTTPException(status_code=400, detail="File/folder name is invalid")
+
+
 def build_content_disposition(disposition: str, filename: str) -> str:
     """Create a safe Content-Disposition header value."""
     # Restrict disposition to a small allowlist to prevent header injection.
@@ -1363,15 +1381,17 @@ async def update_file(
         raise HTTPException(status_code=404, detail="File not found")
     
     if update.name is not None:
+        safe_name = sanitize_rename_target(update.name)
         old_name = file.name
-        file.name = update.name
+        file.name = safe_name
         activity = ActivityLog(
             user_id=current_user.id,
             action="rename",
             file_name=f"{old_name} → {update.name}",
         )
         db.add(activity)
-    
+        activity.file_name = f"{old_name} -> {safe_name}"
+
     if update.path is not None:
         file.path = serialize_path(update.path)
         activity = ActivityLog(

--- a/backend/test_rename_sanitization.py
+++ b/backend/test_rename_sanitization.py
@@ -1,0 +1,132 @@
+import os
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
+
+from app.routers.files import sanitize_rename_target, update_file  # noqa: E402
+from app.schemas import FileUpdate  # noqa: E402
+
+
+def make_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "PATCH",
+            "scheme": "http",
+            "path": "/api/files/file-1",
+            "headers": [(b"host", b"testserver")],
+            "server": ("testserver", 80),
+        }
+    )
+
+
+class DummyResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+
+def make_file(name: str, file_type: str = "file") -> SimpleNamespace:
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id="file-1",
+        name=name,
+        type=file_type,
+        mime_type="text/plain" if file_type != "folder" else None,
+        size=1 if file_type != "folder" else 0,
+        path="[]",
+        is_starred=False,
+        is_trashed=False,
+        thumbnail_path=None,
+        version=1,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def make_db(file_obj: SimpleNamespace):
+    db = SimpleNamespace()
+    db.execute = AsyncMock(return_value=DummyResult(file_obj))
+    db.add = Mock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+class RenameSanitizationTests(unittest.IsolatedAsyncioTestCase):
+    def test_rejects_names_that_collapse_to_empty(self):
+        with self.assertRaises(HTTPException) as ctx:
+            sanitize_rename_target(" \u202e..\x00 ")
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "File/folder name is invalid")
+
+    def test_allows_literal_unnamed(self):
+        self.assertEqual(sanitize_rename_target("unnamed"), "unnamed")
+
+    async def test_file_rename_sanitizes_problematic_characters(self):
+        file_obj = make_file("old.txt")
+        db = make_db(file_obj)
+        current_user = SimpleNamespace(id="user-1")
+
+        response = await update_file(
+            request=make_request(),
+            file_id=file_obj.id,
+            update=FileUpdate(name="project/\nnotes.txt"),
+            current_user=current_user,
+            db=db,
+        )
+
+        self.assertEqual(file_obj.name, "project__notes.txt")
+        self.assertEqual(response.name, "project__notes.txt")
+        self.assertEqual(db.add.call_count, 1)
+        activity = db.add.call_args.args[0]
+        self.assertEqual(activity.action, "rename")
+        self.assertIn("project__notes.txt", activity.file_name)
+
+    async def test_folder_rename_uses_the_same_rules(self):
+        folder = make_file("Quarterly", file_type="folder")
+        db = make_db(folder)
+        current_user = SimpleNamespace(id="user-1")
+
+        response = await update_file(
+            request=make_request(),
+            file_id=folder.id,
+            update=FileUpdate(name="FY2026/Reports\r\n"),
+            current_user=current_user,
+            db=db,
+        )
+
+        self.assertEqual(folder.name, "FY2026_Reports__")
+        self.assertEqual(response.name, "FY2026_Reports__")
+
+    async def test_rename_rejects_invalid_names_without_mutating_file(self):
+        file_obj = make_file("keep.txt")
+        db = make_db(file_obj)
+        current_user = SimpleNamespace(id="user-1")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await update_file(
+                request=make_request(),
+                file_id=file_obj.id,
+                update=FileUpdate(name=" \u202e..\x00 "),
+                current_user=current_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(file_obj.name, "keep.txt")
+        db.add.assert_not_called()
+        db.flush.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`ActivityLog` for rename operations was constructed with raw `update.name` (unsanitized, using `→`) and then immediately overwritten with `safe_name` (using `->`). This mixed arrow formats and briefly held unsanitized user input in the log entry.

## Changes

- **`backend/app/routers/files.py`**: Construct `ActivityLog` once, directly with `safe_name` and a consistent `->` arrow — removes the redundant post-construction reassignment.

```python
# Before
activity = ActivityLog(
    user_id=current_user.id,
    action="rename",
    file_name=f"{old_name} → {update.name}",  # raw input, wrong arrow
)
db.add(activity)
activity.file_name = f"{old_name} -> {safe_name}"  # redundant overwrite

# After
activity = ActivityLog(
    user_id=current_user.id,
    action="rename",
    file_name=f"{old_name} -> {safe_name}",  # sanitized, single assignment
)
db.add(activity)
```