### PR TITLE
[codex] fix security audit findings

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -228,14 +228,8 @@ async def get_current_user(
         raise credentials_exception
 
     session_id: str | None = payload.get("sid")
-    # Transition support: legacy tokens issued before session tracking was introduced
-    # may not carry a 'sid' claim. Accept them as untracked sessions so existing users
-    # are not forcibly signed out after deploy. Note that these tokens cannot be
-    # individually revoked via device management. Once all clients have re-authenticated
-    # and received session-aware tokens, this branch should be removed to enforce
-    # full session validation for all tokens.
     if session_id is None:
-        return user
+        raise credentials_exception
 
     session_result = await db.execute(
         select(UserSession).where(

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -37,6 +37,7 @@ from app.config import get_settings
 from app.db_utils import LIKE_ESCAPE_CHAR, escape_like_literal
 from app.search_index import build_match_context, build_search_document
 from app.thumbnails import generate_thumbnail, can_generate_thumbnail
+from app.tree_validation import normalize_tree_path, sanitize_tree_name
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -73,20 +74,7 @@ def sanitize_filename(filename: Optional[str]) -> str:
 
 def sanitize_rename_target(filename: Optional[str]) -> str:
     """Normalize rename input and reject values that collapse to an empty name."""
-    safe_name = sanitize_filename(filename)
-    if safe_name != "unnamed":
-        return safe_name
-
-    raw_name = (filename or "").replace("\x00", "")
-    for char in raw_name:
-        if char in {"/", "\\", "\r", "\n"}:
-            return safe_name
-        if unicodedata.category(char).startswith("C"):
-            continue
-        if char not in {" ", "."}:
-            return safe_name
-
-    raise HTTPException(status_code=400, detail="File/folder name is invalid")
+    return sanitize_tree_name(filename)
 
 
 def build_content_disposition(disposition: str, filename: str) -> str:
@@ -309,6 +297,27 @@ def get_uploaded_chunks(temp_dir: str, metadata: dict) -> tuple[list[int], int]:
     uploaded_chunks = sorted(set(uploaded_chunks))
     uploaded_bytes = min(uploaded_bytes, metadata["total_size"])
     return uploaded_chunks, uploaded_bytes
+
+
+async def ensure_folder_path_exists(db: AsyncSession, user_id: str, path: List[str]) -> None:
+    if not path:
+        return
+
+    parent_path = path[:-1]
+    folder_name = path[-1]
+    result = await db.execute(
+        select(FileModel.id).where(
+            and_(
+                FileModel.owner_id == user_id,
+                FileModel.type == "folder",
+                FileModel.name == folder_name,
+                FileModel.path.in_(get_serialized_path_variants(parent_path)),
+                FileModel.is_trashed == False,
+            )
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=400, detail="Destination folder does not exist")
 
 
 async def get_next_version_number(db: AsyncSession, file_id: str) -> int:
@@ -1523,7 +1532,10 @@ async def update_file(
     
     if not file:
         raise HTTPException(status_code=404, detail="File not found")
-    
+
+    old_path = parse_path(file.path)
+    old_full_path = old_path + [file.name]
+
     if update.name is not None:
         safe_name = sanitize_rename_target(update.name)
         old_name = file.name
@@ -1536,7 +1548,13 @@ async def update_file(
         db.add(activity)
 
     if update.path is not None:
-        file.path = serialize_path(update.path)
+        normalized_path = normalize_tree_path(update.path)
+        await ensure_folder_path_exists(db, current_user.id, normalized_path)
+
+        if file.type == "folder" and normalized_path[:len(old_full_path)] == old_full_path:
+            raise HTTPException(status_code=400, detail="Cannot move a folder into itself")
+
+        file.path = serialize_path(normalized_path)
         activity = ActivityLog(
             user_id=current_user.id,
             action="move",
@@ -1553,6 +1571,24 @@ async def update_file(
                 file_name=file.name,
             )
             db.add(activity)
+
+    if file.type == "folder" and (update.name is not None or update.path is not None):
+        new_full_path = parse_path(file.path) + [file.name]
+        folder_path_prefixes = get_serialized_path_prefixes(old_full_path)
+        children_result = await db.execute(
+            select(FileModel).where(
+                and_(
+                    FileModel.owner_id == current_user.id,
+                    FileModel.id != file.id,
+                    or_(*[FileModel.path.like(prefix) for prefix in folder_path_prefixes]),
+                )
+            )
+        )
+        for child in children_result.scalars().all():
+            child_path = parse_path(child.path)
+            if child_path[:len(old_full_path)] != old_full_path:
+                continue
+            child.path = serialize_path(new_full_path + child_path[len(old_full_path):])
     
     file.updated_at = datetime.now(timezone.utc)
     await db.flush()

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -14,13 +14,13 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Query, Request
 from fastapi.responses import FileResponse, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_, or_, func
+from sqlalchemy import select, and_, or_, func, update as sql_update
 from sqlalchemy.exc import IntegrityError
 import logging
 
 from app.database import get_db
 from app.limiter import limiter
-from app.models import User, File as FileModel, ActivityLog, FileVersion
+from app.models import User, File as FileModel, ActivityLog, FileVersion, ShareLink
 from app.schemas import (
     FileResponse as FileResponseSchema,
     FileUpdate,
@@ -1584,6 +1584,7 @@ async def trash_file(
     file.is_trashed = True
     file.trashed_at = now
     file.updated_at = now
+    affected_ids = [file.id]
     
     # If folder, recursively trash all children
     if file.type == "folder":
@@ -1601,6 +1602,17 @@ async def trash_file(
         for child in children_result.scalars().all():
             child.is_trashed = True
             child.trashed_at = now
+            affected_ids.append(child.id)
+
+    await db.execute(
+        sql_update(ShareLink)
+        .where(
+            ShareLink.owner_id == current_user.id,
+            ShareLink.file_id.in_(affected_ids),
+            ShareLink.is_active.is_(True),
+        )
+        .values(is_active=False)
+    )
     
     activity = ActivityLog(
         user_id=current_user.id,

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -37,7 +37,7 @@ from app.config import get_settings
 from app.db_utils import LIKE_ESCAPE_CHAR, escape_like_literal
 from app.search_index import build_match_context, build_search_document
 from app.thumbnails import generate_thumbnail, can_generate_thumbnail
-from app.tree_validation import normalize_tree_path, sanitize_tree_name
+from app.tree_validation import normalize_tree_path, sanitize_tree_name, ensure_folder_path_exists
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -297,27 +297,6 @@ def get_uploaded_chunks(temp_dir: str, metadata: dict) -> tuple[list[int], int]:
     uploaded_chunks = sorted(set(uploaded_chunks))
     uploaded_bytes = min(uploaded_bytes, metadata["total_size"])
     return uploaded_chunks, uploaded_bytes
-
-
-async def ensure_folder_path_exists(db: AsyncSession, user_id: str, path: List[str]) -> None:
-    if not path:
-        return
-
-    parent_path = path[:-1]
-    folder_name = path[-1]
-    result = await db.execute(
-        select(FileModel.id).where(
-            and_(
-                FileModel.owner_id == user_id,
-                FileModel.type == "folder",
-                FileModel.name == folder_name,
-                FileModel.path.in_(get_serialized_path_variants(parent_path)),
-                FileModel.is_trashed == False,
-            )
-        )
-    )
-    if result.scalar_one_or_none() is None:
-        raise HTTPException(status_code=400, detail="Destination folder does not exist")
 
 
 async def get_next_version_number(db: AsyncSession, file_id: str) -> int:

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -1575,12 +1575,23 @@ async def update_file(
     if file.type == "folder" and (update.name is not None or update.path is not None):
         new_full_path = parse_path(file.path) + [file.name]
         folder_path_prefixes = get_serialized_path_prefixes(old_full_path)
+        escaped_folder_path_prefixes = [
+            (
+                f"{escape_like_literal(prefix[:-1])}%"
+                if prefix.endswith("%")
+                else escape_like_literal(prefix)
+            )
+            for prefix in folder_path_prefixes
+        ]
         children_result = await db.execute(
             select(FileModel).where(
                 and_(
                     FileModel.owner_id == current_user.id,
                     FileModel.id != file.id,
-                    or_(*[FileModel.path.like(prefix) for prefix in folder_path_prefixes]),
+                    or_(*[
+                        FileModel.path.like(prefix, escape=LIKE_ESCAPE_CHAR)
+                        for prefix in escaped_folder_path_prefixes
+                    ]),
                 )
             )
         )

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -12,6 +12,7 @@ from app.database import get_db
 from app.models import User, File as FileModel, ActivityLog, ShareLink
 from app.schemas import FolderCreate, FileResponse as FileResponseSchema
 from app.auth import get_current_user
+from app.tree_validation import normalize_tree_path, sanitize_tree_name
 
 router = APIRouter(prefix="/api/folders", tags=["Folders"])
 
@@ -42,6 +43,27 @@ def get_serialized_path_prefixes(path: List[str]) -> List[str]:
     return [f"{variant[:-1]}%" for variant in get_serialized_path_variants(path)]
 
 
+async def ensure_folder_path_exists(db: AsyncSession, user_id: str, path: List[str]) -> None:
+    if not path:
+        return
+
+    parent_path = path[:-1]
+    folder_name = path[-1]
+    result = await db.execute(
+        select(FileModel.id).where(
+            and_(
+                FileModel.owner_id == user_id,
+                FileModel.type == "folder",
+                FileModel.name == folder_name,
+                FileModel.path.in_(get_serialized_path_variants(parent_path)),
+                FileModel.is_trashed == False,
+            )
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=400, detail="Parent folder does not exist")
+
+
 @router.post("", response_model=FileResponseSchema, status_code=status.HTTP_201_CREATED)
 async def create_folder(
     folder: FolderCreate,
@@ -49,13 +71,17 @@ async def create_folder(
     db: AsyncSession = Depends(get_db)
 ):
     """Create a new folder"""
+    normalized_name = sanitize_tree_name(folder.name)
+    normalized_path = normalize_tree_path(folder.path)
+    await ensure_folder_path_exists(db, current_user.id, normalized_path)
+
     # Check if folder with same name exists in same path
     existing = await db.execute(
         select(FileModel).where(
             and_(
                 FileModel.owner_id == current_user.id,
-                FileModel.name == folder.name,
-                FileModel.path.in_(get_serialized_path_variants(folder.path)),
+                FileModel.name == normalized_name,
+                FileModel.path.in_(get_serialized_path_variants(normalized_path)),
                 FileModel.type == "folder",
                 FileModel.is_trashed == False,
             )
@@ -69,10 +95,10 @@ async def create_folder(
         )
     
     new_folder = FileModel(
-        name=folder.name,
+        name=normalized_name,
         type="folder",
         size=0,
-        path=serialize_path(folder.path),
+        path=serialize_path(normalized_path),
         owner_id=current_user.id,
         version=1,
     )
@@ -83,7 +109,7 @@ async def create_folder(
     activity = ActivityLog(
         user_id=current_user.id,
         action="create_folder",
-        file_name=folder.name,
+        file_name=normalized_name,
     )
     db.add(activity)
     

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -12,7 +12,7 @@ from app.database import get_db
 from app.models import User, File as FileModel, ActivityLog, ShareLink
 from app.schemas import FolderCreate, FileResponse as FileResponseSchema
 from app.auth import get_current_user
-from app.tree_validation import normalize_tree_path, sanitize_tree_name
+from app.tree_validation import normalize_tree_path, sanitize_tree_name, ensure_folder_path_exists
 
 router = APIRouter(prefix="/api/folders", tags=["Folders"])
 
@@ -41,27 +41,6 @@ def get_serialized_path_variants(path: List[str]) -> List[str]:
 def get_serialized_path_prefixes(path: List[str]) -> List[str]:
     """Return LIKE prefixes for all known serialized path forms."""
     return [f"{variant[:-1]}%" for variant in get_serialized_path_variants(path)]
-
-
-async def ensure_folder_path_exists(db: AsyncSession, user_id: str, path: List[str]) -> None:
-    if not path:
-        return
-
-    parent_path = path[:-1]
-    folder_name = path[-1]
-    result = await db.execute(
-        select(FileModel.id).where(
-            and_(
-                FileModel.owner_id == user_id,
-                FileModel.type == "folder",
-                FileModel.name == folder_name,
-                FileModel.path.in_(get_serialized_path_variants(parent_path)),
-                FileModel.is_trashed == False,
-            )
-        )
-    )
-    if result.scalar_one_or_none() is None:
-        raise HTTPException(status_code=400, detail="Parent folder does not exist")
 
 
 @router.post("", response_model=FileResponseSchema, status_code=status.HTTP_201_CREATED)

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -6,10 +6,10 @@ from typing import List
 from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_, or_
+from sqlalchemy import select, and_, or_, update as sql_update
 
 from app.database import get_db
-from app.models import User, File as FileModel, ActivityLog
+from app.models import User, File as FileModel, ActivityLog, ShareLink
 from app.schemas import FolderCreate, FileResponse as FileResponseSchema
 from app.auth import get_current_user
 
@@ -140,11 +140,13 @@ async def delete_folder(
         )
     )
     children = children_result.scalars().all()
+    affected_ids = [folder.id]
     
     # Trash all children
     for child in children:
         child.is_trashed = True
         child.trashed_at = datetime.now(timezone.utc)
+        affected_ids.append(child.id)
     
     # Trash the folder itself
     folder.is_trashed = True
@@ -157,5 +159,15 @@ async def delete_folder(
         file_name=folder.name,
     )
     db.add(activity)
-    
+
+    await db.execute(
+        sql_update(ShareLink)
+        .where(
+            ShareLink.owner_id == current_user.id,
+            ShareLink.file_id.in_(affected_ids),
+            ShareLink.is_active == True,
+        )
+        .values(is_active=False)
+    )
+
     await db.flush()

--- a/backend/app/routers/sharing.py
+++ b/backend/app/routers/sharing.py
@@ -154,6 +154,23 @@ async def get_my_share_links(
 
 
 @router.post("/{token}")
+async def _deactivate_share_link_for_trashed_file(
+    db: AsyncSession,
+    link: ShareLink
+) -> None:
+    """Persistently deactivate an existing share link for a trashed file."""
+    if not link.is_active:
+        return
+
+    await db.execute(
+        update(ShareLink)
+        .where(ShareLink.id == link.id)
+        .values(is_active=False)
+    )
+    await db.commit()
+    link.is_active = False
+
+
 @limiter.limit("60/minute")
 async def access_shared_file(
     request: Request,
@@ -174,6 +191,7 @@ async def access_shared_file(
     link, file = row[0], row[1]
 
     if file.is_trashed:
+        await _deactivate_share_link_for_trashed_file(db, link)
         raise HTTPException(status_code=410, detail="This file is no longer shared")
 
     # Check if active

--- a/backend/app/routers/sharing.py
+++ b/backend/app/routers/sharing.py
@@ -153,7 +153,6 @@ async def get_my_share_links(
     return links
 
 
-@router.post("/{token}")
 async def _deactivate_share_link_for_trashed_file(
     db: AsyncSession,
     link: ShareLink
@@ -171,6 +170,7 @@ async def _deactivate_share_link_for_trashed_file(
     link.is_active = False
 
 
+@router.post("/{token}")
 @limiter.limit("60/minute")
 async def access_shared_file(
     request: Request,

--- a/backend/app/routers/sharing.py
+++ b/backend/app/routers/sharing.py
@@ -71,6 +71,8 @@ async def create_share_link(
 
     if file.type == "folder":
         raise HTTPException(status_code=400, detail="Cannot share folders directly")
+    if file.is_trashed:
+        raise HTTPException(status_code=400, detail="Cannot share files that are in trash")
 
     # Build share link
     share_link = ShareLink(
@@ -171,6 +173,9 @@ async def access_shared_file(
 
     link, file = row[0], row[1]
 
+    if file.is_trashed:
+        raise HTTPException(status_code=410, detail="This file is no longer shared")
+
     # Check if active
     if not link.is_active:
         raise HTTPException(status_code=410, detail="This share link has been revoked")
@@ -226,6 +231,9 @@ async def download_shared_file(
         raise HTTPException(status_code=404, detail="Share link not found")
 
     link, file = row[0], row[1]
+
+    if file.is_trashed:
+        raise HTTPException(status_code=410, detail="This file is no longer shared")
 
     # Validate
     if not link.is_active:

--- a/backend/app/tree_validation.py
+++ b/backend/app/tree_validation.py
@@ -1,0 +1,36 @@
+"""
+Validation helpers for folder/file tree metadata.
+"""
+import unicodedata
+from typing import List
+
+from fastapi import HTTPException
+
+
+def sanitize_tree_name(name: str | None) -> str:
+    """Normalize a single folder/file path segment."""
+    if name is None:
+        raise HTTPException(status_code=400, detail="File/folder name is invalid")
+
+    sanitized_chars: list[str] = []
+    for char in name.replace("\x00", ""):
+        if char in {"/", "\\", "\r", "\n"}:
+            sanitized_chars.append("_")
+            continue
+        if unicodedata.category(char).startswith("C"):
+            continue
+        sanitized_chars.append(char)
+
+    sanitized = "".join(sanitized_chars).strip().strip(".")
+    if not sanitized:
+        raise HTTPException(status_code=400, detail="File/folder name is invalid")
+    return sanitized
+
+
+def normalize_tree_path(path: List[str] | None) -> List[str]:
+    """Validate and normalize a JSON path array from the client."""
+    if path is None:
+        return []
+    if not isinstance(path, list):
+        raise HTTPException(status_code=400, detail="Path is invalid")
+    return [sanitize_tree_name(segment) for segment in path]

--- a/backend/app/tree_validation.py
+++ b/backend/app/tree_validation.py
@@ -8,27 +8,24 @@ from fastapi import HTTPException
 
 
 def sanitize_tree_name(name: str | None) -> str:
-    """Normalize a single folder/file path segment."""
-    if name is None:
+    """Validate a single folder/file path segment without rewriting it."""
+    if name is None or name == "":
         raise HTTPException(status_code=400, detail="File/folder name is invalid")
 
-    sanitized_chars: list[str] = []
-    for char in name.replace("\x00", ""):
-        if char in {"/", "\\", "\r", "\n"}:
-            sanitized_chars.append("_")
-            continue
+    if name != name.strip() or name != name.strip("."):
+        raise HTTPException(status_code=400, detail="File/folder name is invalid")
+
+    for char in name:
+        if char in {"/", "\\", "\r", "\n", "\x00"}:
+            raise HTTPException(status_code=400, detail="File/folder name is invalid")
         if unicodedata.category(char).startswith("C"):
-            continue
-        sanitized_chars.append(char)
+            raise HTTPException(status_code=400, detail="File/folder name is invalid")
 
-    sanitized = "".join(sanitized_chars).strip().strip(".")
-    if not sanitized:
-        raise HTTPException(status_code=400, detail="File/folder name is invalid")
-    return sanitized
+    return name
 
 
 def normalize_tree_path(path: List[str] | None) -> List[str]:
-    """Validate and normalize a JSON path array from the client."""
+    """Validate a JSON path array from the client without changing segments."""
     if path is None:
         return []
     if not isinstance(path, list):

--- a/backend/app/tree_validation.py
+++ b/backend/app/tree_validation.py
@@ -5,6 +5,8 @@ import unicodedata
 from typing import List
 
 from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, and_
 
 
 def sanitize_tree_name(name: str | None) -> str:
@@ -31,3 +33,46 @@ def normalize_tree_path(path: List[str] | None) -> List[str]:
     if not isinstance(path, list):
         raise HTTPException(status_code=400, detail="Path is invalid")
     return [sanitize_tree_name(segment) for segment in path]
+
+
+async def ensure_folder_path_exists(
+    db: AsyncSession,
+    user_id: str,
+    path: List[str],
+    *,
+    error_detail: str = "Parent folder does not exist",
+) -> None:
+    """Check that every segment of *path* resolves to a real, non-trashed folder
+    belonging to *user_id*.  Raises HTTP 400 when the folder cannot be found."""
+    if not path:
+        return
+
+    # Import here to avoid a top-level circular-import with models → database.
+    from app.models import File as FileModel  # noqa: PLC0415
+
+    def _serialize(p: List[str]) -> str:
+        import json
+        return json.dumps(p, separators=(",", ":"))
+
+    def _serialize_legacy(p: List[str]) -> str:
+        import json
+        return json.dumps(p)
+
+    def _path_variants(p: List[str]) -> List[str]:
+        return list({_serialize(p), _serialize_legacy(p)})
+
+    parent_path = path[:-1]
+    folder_name = path[-1]
+    result = await db.execute(
+        select(FileModel.id).where(
+            and_(
+                FileModel.owner_id == user_id,
+                FileModel.type == "folder",
+                FileModel.name == folder_name,
+                FileModel.path.in_(_path_variants(parent_path)),
+                FileModel.is_trashed == False,  # noqa: E712
+            )
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=400, detail=error_detail)

--- a/backend/app/tree_validation.py
+++ b/backend/app/tree_validation.py
@@ -1,6 +1,7 @@
 """
 Validation helpers for folder/file tree metadata.
 """
+import json
 import unicodedata
 from typing import List
 
@@ -35,6 +36,18 @@ def normalize_tree_path(path: List[str] | None) -> List[str]:
     return [sanitize_tree_name(segment) for segment in path]
 
 
+def _serialize_path(p: List[str]) -> str:
+    return json.dumps(p, separators=(",", ":"))
+
+
+def _serialize_path_legacy(p: List[str]) -> str:
+    return json.dumps(p)
+
+
+def _path_variants(p: List[str]) -> List[str]:
+    return list({_serialize_path(p), _serialize_path_legacy(p)})
+
+
 async def ensure_folder_path_exists(
     db: AsyncSession,
     user_id: str,
@@ -49,17 +62,6 @@ async def ensure_folder_path_exists(
 
     # Import here to avoid a top-level circular-import with models → database.
     from app.models import File as FileModel  # noqa: PLC0415
-
-    def _serialize(p: List[str]) -> str:
-        import json
-        return json.dumps(p, separators=(",", ":"))
-
-    def _serialize_legacy(p: List[str]) -> str:
-        import json
-        return json.dumps(p)
-
-    def _path_variants(p: List[str]) -> List[str]:
-        return list({_serialize(p), _serialize_legacy(p)})
 
     parent_path = path[:-1]
     folder_name = path[-1]

--- a/backend/test_auth_security.py
+++ b/backend/test_auth_security.py
@@ -1,14 +1,29 @@
 import os
 import unittest
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import HTTPException
+from jose import jwt
 
 os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
 
 from app.auth import (  # noqa: E402
     build_password_reset_fingerprint,
+    create_access_token,
     create_password_reset_token,
+    get_current_user,
     verify_password_reset_token,
 )
+from app.config import get_settings  # noqa: E402
 
+settings = get_settings()
+
+
+# ---------------------------------------------------------------------------
+# Password-reset token tests (pre-existing)
+# ---------------------------------------------------------------------------
 
 class PasswordResetTokenTests(unittest.TestCase):
     def test_password_reset_token_is_bound_to_current_password_hash(self):
@@ -25,6 +40,139 @@ class PasswordResetTokenTests(unittest.TestCase):
             payload["password_fingerprint"],
             build_password_reset_fingerprint("hash-two"),
         )
+
+
+# ---------------------------------------------------------------------------
+# get_current_user: session-backed token enforcement tests
+# ---------------------------------------------------------------------------
+
+def _make_user(user_id: str = "user-1") -> SimpleNamespace:
+    return SimpleNamespace(id=user_id, username="tester", email="t@example.com")
+
+
+def _make_session(
+    session_id: str = "sess-1",
+    user_id: str = "user-1",
+    *,
+    revoked: bool = False,
+    expired: bool = False,
+) -> SimpleNamespace:
+    if expired:
+        expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    else:
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    return SimpleNamespace(
+        id=session_id,
+        user_id=user_id,
+        revoked_at=datetime.now(timezone.utc) if revoked else None,
+        expires_at=expires_at,
+        last_seen_at=None,
+    )
+
+
+def _make_db_for_user_lookup(user, session):
+    """Return a mock db that resolves user on the first execute and session on the second."""
+    call_count = 0
+
+    class _Result:
+        def __init__(self, value):
+            self._value = value
+
+        def scalar_one_or_none(self):
+            return self._value
+
+    async def fake_execute(_stmt):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _Result(user)
+        return _Result(session)
+
+    db = SimpleNamespace()
+    db.execute = fake_execute
+    return db
+
+
+class GetCurrentUserSessionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_token_without_sid_raises_401(self):
+        """Access tokens that carry no session id must be rejected."""
+        payload = {"sub": "user-1", "type": "access"}
+        db = AsyncMock()  # DB should not even be consulted for the session check.
+
+        # We still need a user result for the first execute call.
+        user = _make_user()
+        db.execute = AsyncMock(return_value=Mock(scalar_one_or_none=Mock(return_value=user)))
+
+        with self.assertRaises(HTTPException) as ctx:
+            await get_current_user(payload=payload, db=db)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    async def test_valid_session_backed_token_returns_user(self):
+        """A token with a valid, non-revoked session id must succeed."""
+        user = _make_user()
+        session = _make_session()
+        db = _make_db_for_user_lookup(user, session)
+
+        payload = {"sub": "user-1", "sid": "sess-1", "type": "access"}
+        result = await get_current_user(payload=payload, db=db)
+
+        self.assertEqual(result.id, "user-1")
+
+    async def test_revoked_session_raises_401(self):
+        """A token pointing to a revoked session must be rejected."""
+        user = _make_user()
+        session = _make_session(revoked=True)
+        db = _make_db_for_user_lookup(user, session)
+
+        payload = {"sub": "user-1", "sid": "sess-1", "type": "access"}
+
+        with self.assertRaises(HTTPException) as ctx:
+            await get_current_user(payload=payload, db=db)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    async def test_expired_session_raises_401(self):
+        """A token pointing to an already-expired session must be rejected."""
+        user = _make_user()
+        session = _make_session(expired=True)
+        db = _make_db_for_user_lookup(user, session)
+
+        payload = {"sub": "user-1", "sid": "sess-1", "type": "access"}
+
+        with self.assertRaises(HTTPException) as ctx:
+            await get_current_user(payload=payload, db=db)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    async def test_missing_session_row_raises_401(self):
+        """A token with a sid that doesn't exist in the DB must be rejected."""
+        user = _make_user()
+        db = _make_db_for_user_lookup(user, None)  # session not found
+
+        payload = {"sub": "user-1", "sid": "nonexistent-sess", "type": "access"}
+
+        with self.assertRaises(HTTPException) as ctx:
+            await get_current_user(payload=payload, db=db)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    async def test_unknown_user_raises_401(self):
+        """A token for a user that no longer exists must be rejected."""
+
+        class _NoUser:
+            def scalar_one_or_none(self):
+                return None
+
+        db = SimpleNamespace()
+        db.execute = AsyncMock(return_value=_NoUser())
+
+        payload = {"sub": "ghost-user", "sid": "sess-1", "type": "access"}
+
+        with self.assertRaises(HTTPException) as ctx:
+            await get_current_user(payload=payload, db=db)
+
+        self.assertEqual(ctx.exception.status_code, 401)
 
 
 if __name__ == "__main__":

--- a/backend/test_rename_sanitization.py
+++ b/backend/test_rename_sanitization.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -26,12 +26,31 @@ def make_request() -> Request:
     )
 
 
+class ScalarsResult:
+    """Mimics the object returned by db.execute(...).scalars().all()."""
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._items
+
+
 class DummyResult:
     def __init__(self, value):
         self.value = value
 
     def scalar_one_or_none(self):
         return self.value
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        # For non-folder files there are no descendants.
+        return []
 
 
 def make_file(name: str, file_type: str = "file") -> SimpleNamespace:
@@ -52,9 +71,21 @@ def make_file(name: str, file_type: str = "file") -> SimpleNamespace:
     )
 
 
-def make_db(file_obj: SimpleNamespace):
+def make_db(file_obj: SimpleNamespace, children=None):
+    """Return a mock db whose first execute() yields *file_obj* and whose
+    subsequent execute() calls yield an empty children list (or *children*)."""
     db = SimpleNamespace()
-    db.execute = AsyncMock(return_value=DummyResult(file_obj))
+    children_result = ScalarsResult(children or [])
+    call_count = 0
+
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return DummyResult(file_obj)
+        return children_result
+
+    db.execute = fake_execute
     db.add = Mock()
     db.flush = AsyncMock()
     db.refresh = AsyncMock()
@@ -72,7 +103,22 @@ class RenameSanitizationTests(unittest.IsolatedAsyncioTestCase):
     def test_allows_literal_unnamed(self):
         self.assertEqual(sanitize_rename_target("unnamed"), "unnamed")
 
-    async def test_file_rename_sanitizes_problematic_characters(self):
+    def test_rejects_name_with_slash(self):
+        with self.assertRaises(HTTPException) as ctx:
+            sanitize_rename_target("project/notes.txt")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_rejects_name_with_newline(self):
+        with self.assertRaises(HTTPException) as ctx:
+            sanitize_rename_target("bad\nname.txt")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_rejects_name_with_leading_space(self):
+        with self.assertRaises(HTTPException) as ctx:
+            sanitize_rename_target(" leading.txt")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_file_rename_accepts_valid_name(self):
         file_obj = make_file("old.txt")
         db = make_db(file_obj)
         current_user = SimpleNamespace(id="user-1")
@@ -80,33 +126,17 @@ class RenameSanitizationTests(unittest.IsolatedAsyncioTestCase):
         response = await update_file(
             request=make_request(),
             file_id=file_obj.id,
-            update=FileUpdate(name="project/\nnotes.txt"),
+            update=FileUpdate(name="new-name.txt"),
             current_user=current_user,
             db=db,
         )
 
-        self.assertEqual(file_obj.name, "project__notes.txt")
-        self.assertEqual(response.name, "project__notes.txt")
+        self.assertEqual(file_obj.name, "new-name.txt")
+        self.assertEqual(response.name, "new-name.txt")
         self.assertEqual(db.add.call_count, 1)
         activity = db.add.call_args.args[0]
         self.assertEqual(activity.action, "rename")
-        self.assertIn("project__notes.txt", activity.file_name)
-
-    async def test_folder_rename_uses_the_same_rules(self):
-        folder = make_file("Quarterly", file_type="folder")
-        db = make_db(folder)
-        current_user = SimpleNamespace(id="user-1")
-
-        response = await update_file(
-            request=make_request(),
-            file_id=folder.id,
-            update=FileUpdate(name="FY2026/Reports\r\n"),
-            current_user=current_user,
-            db=db,
-        )
-
-        self.assertEqual(folder.name, "FY2026_Reports__")
-        self.assertEqual(response.name, "FY2026_Reports__")
+        self.assertIn("new-name.txt", activity.file_name)
 
     async def test_rename_rejects_invalid_names_without_mutating_file(self):
         file_obj = make_file("keep.txt")
@@ -126,6 +156,84 @@ class RenameSanitizationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(file_obj.name, "keep.txt")
         db.add.assert_not_called()
         db.flush.assert_not_awaited()
+
+    async def test_file_rename_rejects_slash_in_name(self):
+        file_obj = make_file("old.txt")
+        db = make_db(file_obj)
+        current_user = SimpleNamespace(id="user-1")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await update_file(
+                request=make_request(),
+                file_id=file_obj.id,
+                update=FileUpdate(name="project/notes.txt"),
+                current_user=current_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(file_obj.name, "old.txt")
+
+    async def test_folder_rename_rejects_control_characters(self):
+        folder = make_file("Quarterly", file_type="folder")
+        db = make_db(folder)
+        current_user = SimpleNamespace(id="user-1")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await update_file(
+                request=make_request(),
+                file_id=folder.id,
+                update=FileUpdate(name="FY2026/Reports\r\n"),
+                current_user=current_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(folder.name, "Quarterly")
+
+    async def test_folder_rename_valid_name(self):
+        folder = make_file("Quarterly", file_type="folder")
+        db = make_db(folder)
+        current_user = SimpleNamespace(id="user-1")
+
+        response = await update_file(
+            request=make_request(),
+            file_id=folder.id,
+            update=FileUpdate(name="AnnualReports"),
+            current_user=current_user,
+            db=db,
+        )
+
+        self.assertEqual(folder.name, "AnnualReports")
+        self.assertEqual(response.name, "AnnualReports")
+
+    async def test_folder_rename_cascades_to_descendants(self):
+        """Renaming a folder should update the path of its children."""
+        import json
+
+        folder = make_file("OldName", file_type="folder")
+        folder.path = "[]"
+
+        child = make_file("child.txt")
+        child.path = '["OldName"]'
+
+        grandchild = make_file("gc.txt")
+        grandchild.path = '["OldName","sub"]'
+
+        db = make_db(folder, children=[child, grandchild])
+        current_user = SimpleNamespace(id="user-1")
+
+        await update_file(
+            request=make_request(),
+            file_id=folder.id,
+            update=FileUpdate(name="NewName"),
+            current_user=current_user,
+            db=db,
+        )
+
+        self.assertEqual(folder.name, "NewName")
+        self.assertEqual(json.loads(child.path), ["NewName"])
+        self.assertEqual(json.loads(grandchild.path), ["NewName", "sub"])
 
 
 if __name__ == "__main__":

--- a/backend/test_rename_sanitization.py
+++ b/backend/test_rename_sanitization.py
@@ -1,3 +1,4 @@
+import json
 import os
 import unittest
 from datetime import datetime, timezone
@@ -209,8 +210,6 @@ class RenameSanitizationTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_folder_rename_cascades_to_descendants(self):
         """Renaming a folder should update the path of its children."""
-        import json
-
         folder = make_file("OldName", file_type="folder")
         folder.path = "[]"
 

--- a/backend/test_sharing_security.py
+++ b/backend/test_sharing_security.py
@@ -1,15 +1,56 @@
 import os
 import unittest
-from unittest.mock import AsyncMock, Mock
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 from fastapi import HTTPException
 from pydantic import ValidationError
+from starlette.requests import Request
 
 os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
 
-from app.models import ShareLink  # noqa: E402
-from app.routers.sharing import reserve_share_download_slot  # noqa: E402
+from app.models import ShareLink, File as FileModel  # noqa: E402
+from app.routers.sharing import (  # noqa: E402
+    reserve_share_download_slot,
+    create_share_link,
+    access_shared_file,
+    _deactivate_share_link_for_trashed_file,
+)
 from app.schemas import ShareLinkCreate  # noqa: E402
+
+
+def make_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/api/share",
+            "headers": [(b"host", b"testserver"), (b"x-forwarded-for", b"127.0.0.1")],
+            "server": ("testserver", 80),
+        }
+    )
+
+
+def make_file(is_trashed: bool = False, file_type: str = "file") -> SimpleNamespace:
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id="file-1",
+        owner_id="user-1",
+        name="test.txt",
+        type=file_type,
+        mime_type="text/plain",
+        size=42,
+        storage_path=None,
+        path="[]",
+        is_trashed=is_trashed,
+        is_starred=False,
+        thumbnail_path=None,
+        version=1,
+        created_at=now,
+        updated_at=now,
+    )
 
 
 class ShareLinkSchemaTests(unittest.TestCase):
@@ -44,6 +85,134 @@ class ShareDownloadSlotTests(unittest.IsolatedAsyncioTestCase):
         await reserve_share_download_slot(db, link)
 
         db.flush.assert_awaited_once()
+
+
+class CreateShareLinkTrashedFileTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_400_when_file_is_trashed(self):
+        """create_share_link must reject files that are in the trash."""
+        trashed_file = make_file(is_trashed=True)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=Mock(scalar_one_or_none=Mock(return_value=trashed_file)))
+        current_user = SimpleNamespace(id="user-1")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_share_link(
+                request=make_request(),
+                data=ShareLinkCreate(file_id="file-1", permission="view"),
+                current_user=current_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("trash", ctx.exception.detail.lower())
+
+    async def test_returns_400_when_sharing_folder(self):
+        """create_share_link must reject folder shares."""
+        folder = make_file(file_type="folder")
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=Mock(scalar_one_or_none=Mock(return_value=folder)))
+        current_user = SimpleNamespace(id="user-1")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_share_link(
+                request=make_request(),
+                data=ShareLinkCreate(file_id="file-1", permission="view"),
+                current_user=current_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_returns_404_when_file_not_found(self):
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=Mock(scalar_one_or_none=Mock(return_value=None)))
+        current_user = SimpleNamespace(id="user-1")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_share_link(
+                request=make_request(),
+                data=ShareLinkCreate(file_id="missing", permission="view"),
+                current_user=current_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+class AccessSharedFileTrashedTests(unittest.IsolatedAsyncioTestCase):
+    def _make_link(self, is_active: bool = True) -> ShareLink:
+        now = datetime.now(timezone.utc)
+        link = ShareLink(id="link-1", file_id="file-1", owner_id="user-1")
+        link.is_active = is_active
+        link.password_hash = None
+        link.expires_at = None
+        link.max_downloads = None
+        link.download_count = 0
+        link.permission = "view"
+        return link
+
+    async def test_access_shared_file_returns_410_when_file_is_trashed(self):
+        """Accessing a share link for a trashed file must return 410."""
+        trashed_file = make_file(is_trashed=True)
+        link = self._make_link()
+
+        row_mock = Mock()
+        row_mock.__getitem__ = Mock(side_effect=lambda i: link if i == 0 else trashed_file)
+        result_mock = Mock()
+        result_mock.first = Mock(return_value=row_mock)
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=result_mock)
+        db.commit = AsyncMock()
+
+        with self.assertRaises(HTTPException) as ctx:
+            await access_shared_file(
+                request=make_request(),
+                token="test-token",
+                body=None,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 410)
+
+    async def test_access_shared_file_deactivates_link_when_file_is_trashed(self):
+        """When the file is trashed, the share link must be deactivated."""
+        trashed_file = make_file(is_trashed=True)
+        link = self._make_link(is_active=True)
+
+        row_mock = Mock()
+        row_mock.__getitem__ = Mock(side_effect=lambda i: link if i == 0 else trashed_file)
+        result_mock = Mock()
+        result_mock.first = Mock(return_value=row_mock)
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=result_mock)
+        db.commit = AsyncMock()
+
+        with self.assertRaises(HTTPException):
+            await access_shared_file(
+                request=make_request(),
+                token="test-token",
+                body=None,
+                db=db,
+            )
+
+        # The link should have been deactivated in the DB.
+        self.assertFalse(link.is_active)
+        db.commit.assert_awaited()
+
+    async def test_deactivate_helper_is_idempotent_for_already_inactive_links(self):
+        """_deactivate_share_link_for_trashed_file should be a no-op when link is already
+        inactive."""
+        link = self._make_link(is_active=False)
+        db = AsyncMock()
+        db.execute = AsyncMock()
+        db.commit = AsyncMock()
+
+        await _deactivate_share_link_for_trashed_file(db, link)
+
+        db.execute.assert_not_awaited()
+        db.commit.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/src/api.js
+++ b/src/api.js
@@ -33,20 +33,19 @@ function buildUploadFingerprint(file, path) {
 
 class ApiService {
     constructor() {
-        this.token = localStorage.getItem('token');
+        this.token = null;
+        localStorage.removeItem('token');
     }
 
     setToken(token) {
         this.token = token;
-        if (token) {
-            localStorage.setItem('token', token);
-        } else {
+        if (!token) {
             localStorage.removeItem('token');
         }
     }
 
     getToken() {
-        return this.token || localStorage.getItem('token');
+        return this.token;
     }
 
     async request(endpoint, options = {}) {


### PR DESCRIPTION
## Summary

This PR closes the security and integrity issues called out in the recent audit by tightening session enforcement, revoking public access when shared files are trashed, removing persistent browser storage for bearer tokens, and validating file-tree metadata on folder operations.

The first issue was a gap between session revocation and token validation. The backend revoked tracked sessions on logout and credential rotation, but it still accepted older access tokens that did not carry a session id. That meant a token issued before session tracking could remain valid for its full lifetime even after the user believed they had signed out or reset their password. This PR now requires every access token to be session-backed, so revocation is enforced consistently.

The second issue was that sharing and trashing had different ideas of file visibility. Public share endpoints only looked up the token and file row, while trashing a file only marked it as trashed. A file could therefore remain reachable through an old share link after it had been moved to trash. This PR blocks new share links for trashed files, refuses public access to trashed files, and proactively deactivates existing links when a file or folder is trashed.

The third issue was frontend token persistence. The app stored the bearer token in `localStorage`, which made any future XSS bug immediately equivalent to account takeover. This PR keeps the token in memory only and clears any stale persisted token on startup, reducing the blast radius of browser-side script injection at the cost of requiring a fresh login after a full page reload.

The fourth issue was file-tree integrity. Folder creation accepted unsanitized names, move operations trusted arbitrary client-supplied path arrays, and folder rename or move operations did not update descendant paths. This PR centralizes tree-name/path normalization, verifies parent and destination folders exist, blocks moving a folder into itself, and cascades folder rename and move changes down to descendant records so the hierarchy stays coherent.

## Validation

I validated the updated code by compiling the backend Python package with `python -m compileall backend/app` and by running a production frontend build with `npm run build`.
