### PR TITLE
fix: batch minor security and bug hardening

### DIFF
--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -20,3 +20,8 @@ def escape_like_literal(value: str) -> str:
         .replace("%", f"{LIKE_ESCAPE_CHAR}%")
         .replace("_", f"{LIKE_ESCAPE_CHAR}_")
     )
+
+
+def prefix_like_pattern(value: str) -> str:
+    """Build a LIKE prefix pattern that treats the prefix as a literal string."""
+    return f"{escape_like_literal(value)}%"

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -23,5 +23,11 @@ def escape_like_literal(value: str) -> str:
 
 
 def prefix_like_pattern(value: str) -> str:
-    """Build a LIKE prefix pattern that treats the prefix as a literal string."""
+    """Build a LIKE prefix pattern that treats the prefix as a literal string.
+
+    The returned pattern contains backslash escapes produced by
+    ``escape_like_literal()``. When using it with SQLAlchemy ``like()`` or
+    ``ilike()``, callers must pass ``escape=LIKE_ESCAPE_CHAR`` so the escaping
+    is interpreted consistently across databases.
+    """
     return f"{escape_like_literal(value)}%"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -2,6 +2,7 @@
 Home Cloud Drive - Authentication Router
 """
 from datetime import datetime, timedelta, timezone
+import ipaddress
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from anyio import to_thread
@@ -110,15 +111,27 @@ def build_password_reset_url(request: Request, token: str) -> str:
 
 def get_client_ip(request: Request) -> str:
     """Extract the most useful client IP available for session tracking."""
+    def parse_ip(value: str | None) -> str | None:
+        if not value:
+            return None
+        candidate = value.split(",", 1)[0].strip()
+        if not candidate:
+            return None
+        try:
+            return str(ipaddress.ip_address(candidate))
+        except ValueError:
+            return None
+
     if settings.trust_proxy_headers:
-        forwarded_for = request.headers.get("x-forwarded-for")
-        if forwarded_for:
-            return forwarded_for.split(",")[0].strip()
-        real_ip = request.headers.get("x-real-ip")
+        forwarded_ip = parse_ip(request.headers.get("x-forwarded-for"))
+        if forwarded_ip:
+            return forwarded_ip
+        real_ip = parse_ip(request.headers.get("x-real-ip"))
         if real_ip:
-            return real_ip.strip()
-    if request.client and request.client.host:
-        return request.client.host
+            return real_ip
+    direct_ip = parse_ip(request.client.host) if request.client and request.client.host else None
+    if direct_ip:
+        return direct_ip
     return "Unknown IP"
 
 

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -34,7 +34,7 @@ from app.schemas import (
 )
 from app.auth import get_current_user
 from app.config import get_settings
-from app.db_utils import LIKE_ESCAPE_CHAR, escape_like_literal
+from app.db_utils import LIKE_ESCAPE_CHAR, escape_like_literal, prefix_like_pattern
 from app.search_index import build_match_context, build_search_document
 from app.shared_access import (
     FileAccessContext,
@@ -154,7 +154,7 @@ def get_serialized_path_variants(path: List[str]) -> List[str]:
 
 def get_serialized_path_prefixes(path: List[str]) -> List[str]:
     """Return LIKE prefixes for all known serialized path forms."""
-    return [f"{variant[:-1]}%" for variant in get_serialized_path_variants(path)]
+    return [prefix_like_pattern(variant[:-1]) for variant in get_serialized_path_variants(path)]
 
 
 def normalize_path(path_json: str) -> str:
@@ -504,7 +504,7 @@ async def search_files(
         conditions.append(
             or_(
                 FileModel.id == shared_root.id,
-                *[FileModel.path.like(prefix) for prefix in path_prefixes],
+                *[FileModel.path.like(prefix, escape=LIKE_ESCAPE_CHAR) for prefix in path_prefixes],
             )
         )
     else:
@@ -1624,14 +1624,6 @@ async def update_file(
     if file.type == "folder" and (update.name is not None or update.path is not None):
         new_full_path = parse_path(file.path) + [file.name]
         folder_path_prefixes = get_serialized_path_prefixes(old_full_path)
-        escaped_folder_path_prefixes = [
-            (
-                f"{escape_like_literal(prefix[:-1])}%"
-                if prefix.endswith("%")
-                else escape_like_literal(prefix)
-            )
-            for prefix in folder_path_prefixes
-        ]
         children_result = await db.execute(
             select(FileModel).where(
                 and_(
@@ -1639,7 +1631,7 @@ async def update_file(
                     FileModel.id != file.id,
                     or_(*[
                         FileModel.path.like(prefix, escape=LIKE_ESCAPE_CHAR)
-                        for prefix in escaped_folder_path_prefixes
+                        for prefix in folder_path_prefixes
                     ]),
                 )
             )
@@ -1687,7 +1679,7 @@ async def trash_file(
             select(FileModel).where(
                 and_(
                     FileModel.owner_id == file.owner_id,
-                    or_(*[FileModel.path.like(prefix) for prefix in folder_path_prefixes]),
+                    or_(*[FileModel.path.like(prefix, escape=LIKE_ESCAPE_CHAR) for prefix in folder_path_prefixes]),
                     FileModel.is_trashed == False,
                 )
             )
@@ -1747,7 +1739,7 @@ async def restore_file(
             select(FileModel).where(
                 and_(
                     FileModel.owner_id == file.owner_id,
-                    or_(*[FileModel.path.like(prefix) for prefix in folder_path_prefixes]),
+                    or_(*[FileModel.path.like(prefix, escape=LIKE_ESCAPE_CHAR) for prefix in folder_path_prefixes]),
                     FileModel.is_trashed == True,
                 )
             )
@@ -1795,7 +1787,7 @@ async def delete_file_permanently(
             select(FileModel).where(
                 and_(
                     FileModel.owner_id == file.owner_id,
-                    or_(*[FileModel.path.like(prefix) for prefix in folder_path_prefixes]),
+                    or_(*[FileModel.path.like(prefix, escape=LIKE_ESCAPE_CHAR) for prefix in folder_path_prefixes]),
                 )
             )
         )

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -12,6 +12,7 @@ from app.database import get_db
 from app.models import User, File as FileModel, ActivityLog, ShareLink
 from app.schemas import FolderCreate, FileResponse as FileResponseSchema
 from app.auth import get_current_user
+from app.db_utils import LIKE_ESCAPE_CHAR, prefix_like_pattern
 from app.shared_access import get_file_access_context, relative_path_within_shared_root, resolve_target_path
 from app.tree_validation import sanitize_tree_name, ensure_folder_path_exists
 
@@ -41,7 +42,7 @@ def get_serialized_path_variants(path: List[str]) -> List[str]:
 
 def get_serialized_path_prefixes(path: List[str]) -> List[str]:
     """Return LIKE prefixes for all known serialized path forms."""
-    return [f"{variant[:-1]}%" for variant in get_serialized_path_variants(path)]
+    return [prefix_like_pattern(variant[:-1]) for variant in get_serialized_path_variants(path)]
 
 
 @router.post("", response_model=FileResponseSchema, status_code=status.HTTP_201_CREATED)
@@ -154,7 +155,7 @@ async def delete_folder(
         select(FileModel).where(
             and_(
                 FileModel.owner_id == folder.owner_id,
-                or_(*[FileModel.path.like(prefix) for prefix in folder_path_prefixes]),
+                or_(*[FileModel.path.like(prefix, escape=LIKE_ESCAPE_CHAR) for prefix in folder_path_prefixes]),
             )
         )
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -249,9 +249,9 @@ class AdminUserResponse(BaseModel):
 
 
 class AdminUserUpdate(BaseModel):
-    storage_quota: Optional[int] = None
+    storage_quota: Optional[int] = Field(None, ge=0)
     is_admin: Optional[bool] = None
-    username: Optional[str] = None
+    username: Optional[str] = Field(None, min_length=3, max_length=50)
     email: Optional[EmailStr] = None
 
 

--- a/backend/app/shared_access.py
+++ b/backend/app/shared_access.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db_utils import prefix_like_pattern
 from app.models import File as FileModel, SharedFolderAccess, User
 from app.tree_validation import normalize_tree_path
 
@@ -63,7 +64,7 @@ def relative_path_within_shared_root(resource: FileModel, shared_root: FileModel
 
 def path_prefixes_for_shared_root(shared_root: FileModel) -> tuple[list[str], list[str]]:
     root_prefix = parse_path(shared_root.path) + [shared_root.name]
-    return root_prefix, [f"{variant[:-1]}%" for variant in get_serialized_path_variants(root_prefix)]
+    return root_prefix, [prefix_like_pattern(variant[:-1]) for variant in get_serialized_path_variants(root_prefix)]
 
 
 def has_required_role(actual_role: str, required_role: str) -> bool:

--- a/backend/test_admin_user_update_validation.py
+++ b/backend/test_admin_user_update_validation.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+
+from pydantic import ValidationError
+
+os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
+
+from app.schemas import AdminUserUpdate  # noqa: E402
+
+
+class AdminUserUpdateValidationTests(unittest.TestCase):
+    def test_rejects_negative_storage_quota(self):
+        with self.assertRaises(ValidationError):
+            AdminUserUpdate(storage_quota=-1)
+
+    def test_rejects_too_short_username(self):
+        with self.assertRaises(ValidationError):
+            AdminUserUpdate(username="ab")
+
+    def test_accepts_valid_partial_update(self):
+        update = AdminUserUpdate(storage_quota=1024, username="alice-admin")
+
+        self.assertEqual(update.storage_quota, 1024)
+        self.assertEqual(update.username, "alice-admin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/test_password_reset_url.py
+++ b/backend/test_password_reset_url.py
@@ -82,6 +82,21 @@ class PasswordResetUrlTests(unittest.TestCase):
 
         self.assertEqual(client_ip, "198.51.100.20")
 
+    def test_client_ip_ignores_invalid_forwarded_header_and_falls_back(self):
+        auth_router.settings.trust_proxy_headers = True
+        request = make_request(
+            "app.example.com",
+            headers={
+                "x-forwarded-for": "not-an-ip",
+                "x-real-ip": "198.51.100.21",
+            },
+            client_host="203.0.113.44",
+        )
+
+        client_ip = auth_router.get_client_ip(request)
+
+        self.assertEqual(client_ip, "198.51.100.21")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/test_path_prefix_escape.py
+++ b/backend/test_path_prefix_escape.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+
+os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
+
+from app.db_utils import prefix_like_pattern  # noqa: E402
+from app.routers.files import get_serialized_path_prefixes as file_path_prefixes  # noqa: E402
+from app.routers.folders import get_serialized_path_prefixes as folder_path_prefixes  # noqa: E402
+from app.shared_access import path_prefixes_for_shared_root  # noqa: E402
+
+
+class PathPrefixEscapeTests(unittest.TestCase):
+    def test_prefix_like_pattern_escapes_sql_wildcards(self):
+        self.assertEqual(prefix_like_pattern('["100%_done"'), '["100\\%\\_done"%')
+
+    def test_file_router_prefixes_escape_literal_wildcards(self):
+        prefixes = file_path_prefixes(["Reports", "100%_done"])
+        self.assertTrue(any("\\%" in prefix and "\\_" in prefix for prefix in prefixes))
+
+    def test_folder_router_prefixes_escape_literal_wildcards(self):
+        prefixes = folder_path_prefixes(["Reports", "100%_done"])
+        self.assertTrue(any("\\%" in prefix and "\\_" in prefix for prefix in prefixes))
+
+    def test_shared_root_prefixes_escape_literal_wildcards(self):
+        shared_root = type("SharedRoot", (), {"path": '["Reports"]', "name": "100%_done"})()
+        _root_path, prefixes = path_prefixes_for_shared_root(shared_root)
+        self.assertTrue(any("\\%" in prefix and "\\_" in prefix for prefix in prefixes))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- escape SQL LIKE wildcard characters when building descendant path-prefix queries for shared folders and file tree operations
- validate admin user updates so negative quotas and undersized usernames are rejected before reaching the router
- sanitize trusted proxy IP extraction so malformed forwarded headers do not get persisted or used in login alerts

## Testing
- `.\\venv\\Scripts\\python.exe -m unittest test_path_prefix_escape test_admin_user_update_validation test_password_reset_url`
- `.\\venv\\Scripts\\python.exe -m unittest test_search_escape test_auth_security`
