### PR TITLE
[codex] audited dependency refresh and small hardening fixes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,8 @@
 # Home Cloud Backend Dependencies
-fastapi==0.109.0
+fastapi==0.136.1
 uvicorn[standard]==0.27.0
-python-multipart==0.0.6
-python-jose[cryptography]==3.3.0
+python-multipart==0.0.27
+python-jose[cryptography]==3.5.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 sqlalchemy==2.0.36
@@ -11,5 +11,5 @@ pydantic>=2.9.0
 pydantic-settings>=2.5.0
 aiofiles==23.2.1
 email-validator==2.1.0
-Pillow==10.4.0
+Pillow==12.2.0
 slowapi==0.1.9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,9 +1530,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -1716,9 +1716,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/AuthPage.jsx
+++ b/src/components/AuthPage.jsx
@@ -38,7 +38,7 @@ export default function AuthPage({ onLogin }) {
     useEffect(() => {
         const container = starsRef.current;
         if (!container) return;
-        container.innerHTML = '';
+        container.replaceChildren();
         const count = window.innerWidth < 768 ? 80 : 120;
         for (let i = 0; i < count; i++) {
             const star = document.createElement('div');
@@ -59,7 +59,7 @@ export default function AuthPage({ onLogin }) {
     useEffect(() => {
         const container = windsRef.current;
         if (!container) return;
-        container.innerHTML = '';
+        container.replaceChildren();
         const positions = [8, 18, 28, 42, 55, 63, 72, 82, 91];
         positions.forEach((top) => {
             const wind = document.createElement('div');

--- a/src/components/FileDetailsPanel.jsx
+++ b/src/components/FileDetailsPanel.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
     X,
     Download,
@@ -56,6 +56,18 @@ export default function FileDetailsPanel({
     onShowVersions,
 }) {
     const Icon = iconConfig[file.type] || iconConfig.default;
+    const [previewUrl, setPreviewUrl] = useState(null);
+
+    useEffect(() => {
+        if (file.type !== "image" || !file.blob) {
+            setPreviewUrl(null);
+            return;
+        }
+
+        const objectUrl = URL.createObjectURL(file.blob);
+        setPreviewUrl(objectUrl);
+        return () => URL.revokeObjectURL(objectUrl);
+    }, [file]);
 
     return (
         <div className="details-panel">
@@ -68,9 +80,9 @@ export default function FileDetailsPanel({
 
             {/* Preview */}
             <div className="details-preview">
-                {file.type === "image" && file.blob ? (
+                {previewUrl ? (
                     <img
-                        src={URL.createObjectURL(file.blob)}
+                        src={previewUrl}
                         alt={file.name}
                         className="details-thumbnail"
                     />

--- a/src/components/FilePreviewModal.jsx
+++ b/src/components/FilePreviewModal.jsx
@@ -46,7 +46,11 @@ export default function FilePreviewModal({
                         URL.revokeObjectURL(url);
                     }
                 })
-                .catch(() => setPreviewUrl(null));
+                .catch(() => {
+                    if (active) {
+                        setPreviewUrl(null);
+                    }
+                });
             return () => {
                 active = false;
                 if (objectUrl) URL.revokeObjectURL(objectUrl);

--- a/src/components/FilePreviewModal.jsx
+++ b/src/components/FilePreviewModal.jsx
@@ -34,12 +34,25 @@ export default function FilePreviewModal({
     // Fetch blob URL for image/video/PDF previews (avoids JWT in URL)
     useEffect(() => {
         if (["image", "video", "pdf"].includes(file.type)) {
+            let active = true;
+            let objectUrl = null;
             setPreviewUrl(null);
             api.fetchPreviewBlob(file.id)
-                .then(url => setPreviewUrl(url))
+                .then(url => {
+                    objectUrl = url;
+                    if (active) {
+                        setPreviewUrl(url);
+                    } else {
+                        URL.revokeObjectURL(url);
+                    }
+                })
                 .catch(() => setPreviewUrl(null));
+            return () => {
+                active = false;
+                if (objectUrl) URL.revokeObjectURL(objectUrl);
+            };
         }
-        return () => { if (previewUrl) URL.revokeObjectURL(previewUrl); };
+        setPreviewUrl(null);
     }, [file]);
 
     // Keyboard navigation

--- a/src/components/StorageChart.jsx
+++ b/src/components/StorageChart.jsx
@@ -40,8 +40,9 @@ export default function StorageChart({ files, storageInfo }) {
     const usedStorage = storageInfo?.used || total;
     const usedPercent = maxStorage > 0 ? ((usedStorage / maxStorage) * 100).toFixed(1) : "0.0";
 
-    const formatSize = (bytes) => {
-        if (bytes === 0) return "0 B";
+    const formatSize = (bytes = 0) => {
+        if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+        if (bytes < 1024) return `${bytes} B`;
         const tb = bytes / (1024 * 1024 * 1024 * 1024);
         if (tb >= 1) return `${tb.toFixed(2)} TB`;
         const gb = bytes / (1024 * 1024 * 1024);

--- a/src/components/UploadProgress.jsx
+++ b/src/components/UploadProgress.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import { Upload, X, CheckCircle, AlertCircle, Clock, Zap } from "lucide-react";
 
 function formatBytes(bytes) {
-    if (bytes === 0) return "0 B";
+    if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
     const k = 1024;
-    const sizes = ["B", "KB", "MB", "GB"];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const sizes = ["B", "KB", "MB", "GB", "TB"];
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }
 

--- a/src/components/UploadProgress.jsx
+++ b/src/components/UploadProgress.jsx
@@ -5,7 +5,7 @@ function formatBytes(bytes) {
     if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
     const k = 1024;
     const sizes = ["B", "KB", "MB", "GB", "TB"];
-    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+    const i = Math.max(0, Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }
 


### PR DESCRIPTION
## What changed

This PR contains five focused security and small-optimization commits:

- Refresh audited dependencies flagged by `npm audit` and `pip-audit`.
- Replace raw auth-page DOM clearing with `replaceChildren()`.
- Revoke file-preview blob URLs from the effect that owns them.
- Clean up details-panel image preview object URLs.
- Harden storage and upload byte formatting for invalid or very large values.

## Why

The audits identified vulnerable frontend/backend dependency pins, including Vite, PostCSS, FastAPI/Starlette, python-multipart, python-jose, and Pillow. The follow-up UI changes are small hardening/optimization fixes that reduce unnecessary blob URL retention and prevent bad progress/storage labels.

## Validation

- `npm.cmd audit --json` reports 0 vulnerabilities.
- `backend\venv\Scripts\python.exe -m pip_audit -r backend\requirements.txt` reports no known vulnerabilities.
- `npm.cmd run build` succeeds after the frontend changes.
- Backend pytest collection has pre-existing local issues: stale inaccessible temp dirs under `backend/_tmp_upload_tests`, plus 9 failures in existing tests around shared-access mocks and password-reset config reading local env. A direct backend file run reached 55 passing tests before those 9 failures.